### PR TITLE
Add README and usage headers for helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# WAN 2.2 Helper Scripts
+
+A collection of small Bash utilities for preparing video datasets. Most scripts
+rely on `ffmpeg`/`ffprobe`; some also require ImageMagick or Perl.
+
+## Scripts
+
+| Script | Description |
+| --- | --- |
+| `combineFirstLastImages.sh` | Combine first and last frame images into a single composite separated by a line. Requires ImageMagick. |
+| `convert_to_16fps.sh` | Convert videos to constant 16 fps MP4 files. Customizable via env vars; optional GPU acceleration. |
+| `convert_to_mp4.sh` | Batch convert animated GIF/WEBP and other video formats to MP4 with high-quality defaults and smart copy. |
+| `extract_first_frames.sh` | Extract the first frame of each MP4 and create matching empty `.txt` files. |
+| `extract_first-last_frames.sh` | Extract first and last frames (with fallbacks for reliable last-frame capture) and create accompanying `.txt` files. |
+| `grab_5_frames.sh` | Grab five evenly spaced frames from a single video file. |
+| `merge_lastframe_into_main.sh` | Merge caption text from `_lastFrame.txt` files into the main caption files, normalizing spacing. |
+
+## License
+
+MIT – see [LICENSE](LICENSE).

--- a/combineFirstLastImages.sh
+++ b/combineFirstLastImages.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# combine_first_last_frames.sh
-# Requires: ImageMagick (magick OR convert/identify)
+# Combine the first and last frame images into a single side-by-side
+# composite separated by a line. Requires ImageMagick (magick or
+# convert/identify).
 set -euo pipefail
 shopt -s nullglob nocaseglob
 

--- a/convert_to_16fps.sh
+++ b/convert_to_16fps.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Convert video files in the current directory to constant 16fps MP4s
+# using ffmpeg. Tweak settings via environment variables; optional
+# h264_nvenc GPU acceleration.
 set -euo pipefail
 # Match files case-insensitively and ignore non-matches
 shopt -s nullglob nocaseglob

--- a/convert_to_mp4.sh
+++ b/convert_to_mp4.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
-# TL;DR slap this in a directory with animated gifs, animated webps, and non-mp4 video files you want to convert into .mp4 files. Then run it, converts all to mp4.
-# Extended: convert_webp_to_mp4.sh (patched)
-# - Robust GIF/WEBP → MP4 conversion. WEBP uses ImageMagick path by default.
-# - General video → MP4 with smart-copy option.
-# - High-quality x264 defaults.
-# - If no inputs/dirs, runs on the script's directory (NON-RECURSIVE).
+# Batch-convert animated GIF/WEBP images and numerous video formats to
+# high-quality MP4. Uses ffmpeg with sensible x264 defaults and can
+# smart-copy already compatible streams. If no inputs are provided, the
+# script processes files in its own directory.
 
 set -euo pipefail
 shopt -s nullglob

--- a/extract_first-last_frames.sh
+++ b/extract_first-last_frames.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# extract_first_and_last_frames.sh
+# Extract both the first and last frames from every MP4 in the current
+# directory, writing matching .txt files. Employs several strategies to
+# reliably grab the final frame.
 set -euo pipefail
 shopt -s nullglob nocaseglob
 

--- a/extract_first_frames.sh
+++ b/extract_first_frames.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# extract_first_frames.sh
-# extracts the first frame of every mp4 in the directory and makes a matching .txt file
+# Extract the first frame of every MP4 in the current directory and create
+# a matching empty .txt file. Useful for preparing caption placeholders.
 set -euo pipefail
 shopt -s nullglob nocaseglob
 

--- a/grab_5_frames.sh
+++ b/grab_5_frames.sh
@@ -1,8 +1,7 @@
-
 #!/usr/bin/env bash
-# grab_5_frames.sh
-# Extract 5 evenly-distributed frames from a video using ffmpeg/ffprobe.
-# Output files: <input_basename>_frame1.jpg ... _frame5.jpg (in the same folder)
+# Extract five evenly spaced frames from a video using ffmpeg and ffprobe.
+# Output files are named <input_basename>_frame1.jpg through
+# <input_basename>_frame5.jpg in the same folder.
 
 set -euo pipefail
 

--- a/merge_lastframe_into_main.sh
+++ b/merge_lastframe_into_main.sh
@@ -1,6 +1,6 @@
-
 #!/usr/bin/env bash
-# merge_lastframe_into_main.sh
+# Merge caption text from *_lastFrame.txt files into their corresponding
+# main .txt files, normalizing spacing and newlines.
 set -euo pipefail
 shopt -s nullglob nocaseglob
 


### PR DESCRIPTION
## Summary
- Add top-level README describing available video helper scripts and dependencies
- Insert usage comments at the beginning of each shell script for clarity

## Testing
- `for f in *.sh; do bash -n "$f" || exit 1; done`


------
https://chatgpt.com/codex/tasks/task_e_68add67fabfc832baed8ed1f60f19da5