### PR TITLE
docs: document lmstudio captioner usage and limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ rely on `ffmpeg`/`ffprobe`; some also require ImageMagick or Perl.
 | `extract_first-last_frames.sh` | Extract first and last frames (with fallbacks for reliable last-frame capture) and create accompanying `.txt` files. |
 | `grab_5_frames.sh` | Grab five evenly spaced frames from a single video file. |
 | `merge_lastframe_into_main.sh` | Merge caption text from `_lastFrame.txt` files into the main caption files, normalizing spacing. |
+| `lmstudio_captioner` | Local web app that captions videos via LM Studio's API. Assistant prefill only appears as a separate pretend reply due to LM Studio API limits; load a model in LM Studio, enable the API in the Developer tab, and paste the model name into the app. |
 
 ## License
 

--- a/lmstudio_captioner/README.md
+++ b/lmstudio_captioner/README.md
@@ -5,17 +5,16 @@ A minimal local web app that wraps the LM Studio OpenAI-compatible API to captio
 It extracts frames from a clip (uniformly spaced or the first N), sends them to your loaded VLM model,
 and writes `.txt` captions (batch mode) or shows them in a chat-like UI (single-clip mode).
 
-## Prefill behavior (fixed)
-Assistant response prefill is implemented via **assistant-prefix continuation**:
-we append a final `role="assistant"` message containing your prefix and set `add_generation_prompt=false`
-so LM Studio / llama.cpp continues from that text. This gives a true prefix instead of a mere instruction.
+## Prefill behavior
+LM Studio's API does not support true assistant prefilling. Any prefix you supply is sent as an extra
+`assistant` message and the model treats it as a prior reply rather than continuing from it.
 
 ## Prereqs
 
 - Python 3.10+
 - `pip install -r requirements.txt`
-- LM Studio running locally with the **OpenAI API Server** enabled (default base URL `http://localhost:1234/v1`).
-- A **vision model** loaded in LM Studio (e.g., Qwen2.5-VL-32B-Instruct).
+- LM Studio running locally. Load a **vision model**, open the **Developer** tab, enable the API server
+  (default base URL `http://localhost:1234/v1`), and copy the model's name into the app's model field.
 
 If your LM Studio server uses a different port/base URL, set:
 ```
@@ -29,7 +28,7 @@ export LMSTUDIO_MODEL="qwen2.5-vl-32b-instruct"
 ## Run
 
 ```bash
-cd lmstudio_captioner_fixed
+cd lmstudio_captioner
 pip install -r requirements.txt
 python app.py
 ```


### PR DESCRIPTION
## Summary
- document lmstudio_captioner in the main script list
- clarify LM Studio's API lacks true assistant prefilling and give usage instructions for loading a model and enabling the API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68addb0d08e0832bb0a3cb4853835ce6