### PR TITLE
docs: add multi-video sync compare tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ rely on `ffmpeg`/`ffprobe`; some also require ImageMagick or Perl.
 | `grab_5_frames.sh` | Grab five evenly spaced frames from a single video file. |
 | `merge_lastframe_into_main.sh` | Merge caption text from `_lastFrame.txt` files into the main caption files, normalizing spacing. |
 | `lmstudio_captioner` | Local web app that captions videos via LM Studio's API. Assistant prefill only appears as a separate pretend reply due to LM Studio API limits; load a model in LM Studio, enable the API in the Developer tab, and paste the model name into the app. |
+| `multi_video_sync_compare.html` | Browser-based tool for loading multiple videos, adjusting per-video offsets, and keeping playback synchronized for side-by-side comparison. |
 
 ## License
 


### PR DESCRIPTION
## Summary
- document the new `multi_video_sync_compare.html` helper in the README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68addc6f6910832b8f798dcd0a69cee0