### PR TITLE
feat: add Windows versions of dataset helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,17 @@ rely on `ffmpeg`/`ffprobe`; some also require ImageMagick or Perl. Windows users
 
 | Script | Description |
 | --- | --- |
-| `combineFirstLastImages.sh` | Combine first and last frame images into a single composite separated by a line. Requires ImageMagick. |
+| `condenseMP4s_to_target_frames.sh` | Condense MP4s longer than a target frame count down to that length at constant FPS. Outputs to `condensed/`. |
 | `convert_to_16fps.sh` | Convert videos to constant 16 fps MP4 files. Customizable via env vars; optional GPU acceleration. |
 | `convert_to_mp4.sh` | Batch convert animated GIF/WEBP and other video formats to MP4 with high-quality defaults and smart copy. |
 | `extract_first_frames.sh` | Extract the first frame of each MP4 and create matching empty `.txt` files. |
 | `extract_first-last_frames.sh` | Extract first and last frames (with fallbacks for reliable last-frame capture) and create accompanying `.txt` files. |
 | `grab_5_frames.sh` | Grab five evenly spaced frames from a single video file. |
+| `make_palindromes.sh` | Create forward+reverse palindromes for short clips, optionally condensing to a target frame count. |
 | `merge_lastframe_into_main.sh` | Merge caption text from `_lastFrame.txt` files into the main caption files, normalizing spacing. |
+| `move_under_frames.sh` | Move MP4s with fewer than N frames into `./under_N_frames/`. |
+| `move_within_x_resolution.sh` | Move MP4s whose average dimension `(W+H)/2` is below a threshold into `./within_X_resolution/`. |
+| `reverse_videos_max_frames.sh` | Reverse videos up to N frames and write them to `./reversed/`. Longer clips are skipped. |
 | `lmstudio_captioner` | Local web app that captions videos via LM Studio's API. Assistant prefill only appears as a separate pretend reply due to LM Studio API limits; load a model in LM Studio, enable the API in the Developer tab, and paste the model name into the app. |
 | `multi_video_sync_compare.html` | Browser-based tool for loading multiple videos, adjusting per-video offsets, and keeping playback synchronized for side-by-side comparison. |
 

--- a/condenseMP4s_to_target_frames.ps1
+++ b/condenseMP4s_to_target_frames.ps1
@@ -1,0 +1,52 @@
+param(
+    [string]$OutDir = "condensed",
+    [int]$FPS = 16,
+    [int]$TargetFrames = 101,
+    [int]$CRF = 18,
+    [string]$PRESET = "slow",
+    [string]$CODEC = "libx264",
+    [switch]$KeepAudio,
+    [switch]$KeepNames,
+    [switch]$Overwrite,
+    [switch]$DryRun
+)
+
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+
+function Count-Frames {
+    param([string]$File)
+    $nb = ffprobe -v error -select_streams v:0 -count_frames -show_entries stream=nb_read_frames -of default=nw=1:nk=1 $File 2>$null
+    if ($nb -match '^[0-9]+$' -and [int]$nb -gt 0) { return [int]$nb }
+    $dur = ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 $File 2>$null
+    if (-not $dur) { $dur = 0 }
+    $rate = ffprobe -v error -select_streams v:0 -show_entries stream=r_frame_rate -of default=nw=1:nk=1 $File 2>$null
+    if (-not $rate) { $rate = '0/1' }
+    $parts = $rate -split '/'
+    if ($parts.Length -ne 2 -or [int]$parts[1] -eq 0) { return 0 }
+    $fps = [double]$parts[0] / [double]$parts[1]
+    return [int]([double]$dur * $fps)
+}
+
+$ffw = '-n'; if ($Overwrite) { $ffw = '-y' }
+
+$processed=0; $made=0; $skipped=0
+Get-ChildItem -Path . -Filter *.mp4 -File | ForEach-Object {
+    $processed++
+    $frames = Count-Frames $_.FullName
+    if (-not ($frames -is [int])) { Write-Host "WARN  $($_.Name): unable to read frame count"; $skipped++; return }
+    if ($frames -le $TargetFrames) { Write-Host "SKIP  $($_.Name)  ($frames ≤ $TargetFrames)"; $skipped++; return }
+    $speed = [double]$frames / [double]$TargetFrames
+    $base = $_.BaseName
+    $suffix = if ($KeepNames) { '' } else { '_condensed' }
+    $out = Join-Path $OutDir ("${base}${suffix}.mp4")
+    Write-Host "MAKE  $($_.Name)  frames_in=$frames  speedup=${speed}x  ->  $out"
+    if ($DryRun) { $made++; return }
+    $vf = "setpts=PTS/$speed,fps=$FPS"
+    if ($KeepAudio) {
+        ffmpeg $ffw -hide_banner -loglevel error -i $_.FullName -filter_complex "[0:v]$vf[v]" -map "[v]" -map 0:a? -frames:v $TargetFrames -c:v $CODEC -preset $PRESET -crf $CRF -pix_fmt yuv420p -c:a aac -b:a 128k -movflags +faststart $out
+    } else {
+        ffmpeg $ffw -hide_banner -loglevel error -i $_.FullName -an -vf $vf -frames:v $TargetFrames -c:v $CODEC -preset $PRESET -crf $CRF -pix_fmt yuv420p -movflags +faststart $out
+    }
+    $made++
+}
+Write-Host "Done. processed=$processed  made=$made  skipped=$skipped  outdir=$OutDir"

--- a/make_palindromes.ps1
+++ b/make_palindromes.ps1
@@ -1,0 +1,59 @@
+param(
+    [int]$MaxFrames = 101,
+    [int]$TargetFrames = 101,
+    [int]$FPS = 16,
+    [int]$CRF = 18,
+    [string]$PRESET = "slow",
+    [string]$CODEC = "libx264",
+    [switch]$EnforceTarget,
+    [switch]$KeepAudio,
+    [switch]$Overwrite,
+    [switch]$DryRun
+)
+$outDir = "palindromes"
+New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+
+function Count-Frames {
+    param([string]$File)
+    $nb = ffprobe -v error -select_streams v:0 -count_frames -show_entries stream=nb_read_frames -of default=nw=1:nk=1 $File 2>$null
+    if ($nb -match '^[0-9]+$' -and [int]$nb -gt 0) { return [int]$nb }
+    $dur = ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 $File 2>$null
+    if (-not $dur) { $dur = 0 }
+    $rate = ffprobe -v error -select_streams v:0 -show_entries stream=avg_frame_rate -of default=nw=1:nk=1 $File 2>$null
+    if (-not $rate) { $rate = '0/1' }
+    $parts = $rate -split '/'
+    if ($parts.Length -ne 2 -or [int]$parts[1] -eq 0) { return 0 }
+    $fps = [double]$parts[0] / [double]$parts[1]
+    return [int]([double]$dur * $fps)
+}
+
+function Speed-For {
+    param([int]$FramesIn,[int]$Target)
+    if ($Target -le 0) { return 1.0 }
+    return [double]$FramesIn / [double]$Target
+}
+
+$ffw = '-n'; if ($Overwrite) { $ffw = '-y' }
+$processed=0; $made=0; $skipped=0; $warned=0
+Get-ChildItem -Path . -Filter *.mp4 -File | ForEach-Object {
+    $processed++
+    $frames = Count-Frames $_.FullName
+    if (-not ($frames -is [int])) { Write-Host "WARN  $($_.Name): could not read frame count"; $warned++; return }
+    if ($frames -gt $MaxFrames) { Write-Host "SKIP  $($_.Name)  ($frames > $MaxFrames)"; $skipped++; return }
+    $palFrames = 2*$frames - 1
+    $speed = 1.0
+    if ($palFrames -gt $TargetFrames) { $speed = Speed-For $palFrames $TargetFrames }
+    elseif ($EnforceTarget -and $palFrames -lt $TargetFrames) { $speed = Speed-For $palFrames $TargetFrames }
+    $out = Join-Path $outDir ("$($_.BaseName)_pal.mp4")
+    Write-Host "MAKE  $($_.Name)  in=$frames  pal=$palFrames  speed=${speed}x  -> $out"
+    if ($DryRun) { $made++; return }
+    if ($KeepAudio) {
+        $fc = "[0:v]split=2[fwd][r0];[r0]reverse,trim=start_frame=1[rev];[fwd][rev]concat=n=2:v=1:a=0,setpts=PTS/$speed,fps=$FPS[v];[0:a]areverse,atrim=start=0.00002[ar];[0:a][ar]concat=n=2:v=0:a=1,asetpts=N/SR/TB[a]"
+        ffmpeg $ffw -hide_banner -loglevel error -i $_.FullName -filter_complex $fc -map "[v]" -map "[a]" -frames:v $TargetFrames -c:v $CODEC -preset $PRESET -crf $CRF -pix_fmt yuv420p -c:a aac -b:a 128k -movflags +faststart $out
+    } else {
+        $fc = "[0:v]split=2[fwd][r0];[r0]reverse,trim=start_frame=1[rev];[fwd][rev]concat=n=2:v=1:a=0,setpts=PTS/$speed,fps=$FPS[v]"
+        ffmpeg $ffw -hide_banner -loglevel error -i $_.FullName -filter_complex $fc -map "[v]" -an -frames:v $TargetFrames -c:v $CODEC -preset $PRESET -crf $CRF -pix_fmt yuv420p -movflags +faststart $out
+    }
+    $made++
+}
+Write-Host "Done. processed=$processed made=$made skipped=$skipped warned=$warned outdir=$outDir"

--- a/move_under_frames.ps1
+++ b/move_under_frames.ps1
@@ -1,0 +1,44 @@
+param(
+    [int]$Frames = 102,
+    [switch]$Recurse,
+    [switch]$DryRun,
+    [switch]$Overwrite
+)
+$destRoot = "under_${Frames}_frames"
+New-Item -ItemType Directory -Force -Path $destRoot | Out-Null
+
+function Count-Frames {
+    param([string]$File)
+    $nb = ffprobe -v error -select_streams v:0 -count_frames -show_entries stream=nb_read_frames -of default=nw=1:nk=1 $File 2>$null
+    if ($nb -match '^[0-9]+$' -and [int]$nb -gt 0) { return [int]$nb }
+    $dur = ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 $File 2>$null
+    if (-not $dur) { $dur = 0 }
+    $rate = ffprobe -v error -select_streams v:0 -show_entries stream=avg_frame_rate -of default=nw=1:nk=1 $File 2>$null
+    if (-not $rate) { $rate = '0/1' }
+    $parts = $rate -split '/'
+    if ($parts.Length -ne 2 -or [int]$parts[1] -eq 0) { return 0 }
+    $fps = [double]$parts[0] / [double]$parts[1]
+    return [int]([double]$dur * $fps)
+}
+
+$opts = @{}
+if ($Recurse) { $opts.Recurse = $true }
+Get-ChildItem -Path . -Filter *.mp4 -File @opts | ForEach-Object {
+    $rel = Resolve-Path -LiteralPath $_.FullName -Relative
+    if ($rel -like "$destRoot*") { Write-Host "SKIP  $rel (already in $destRoot)"; return }
+    $frames = Count-Frames $_.FullName
+    if (-not ($frames -is [int])) { Write-Host "WARN  $rel: unable to read frame count"; return }
+    if ($frames -lt $Frames) {
+        $relDir = Split-Path $rel
+        $destDir = Join-Path $destRoot $relDir
+        New-Item -ItemType Directory -Force -Path $destDir | Out-Null
+        Write-Host "MOVE  $rel  ($frames < $Frames) -> $destDir/"
+        if (-not $DryRun) {
+            $moveArgs = @{}
+            if ($Overwrite) { $moveArgs.Force = $true }
+            Move-Item -LiteralPath $_.FullName -Destination $destDir @moveArgs
+        }
+    } else {
+        Write-Host "KEEP  $rel  ($frames ≥ $Frames)"
+    }
+}

--- a/move_within_x_resolution.ps1
+++ b/move_within_x_resolution.ps1
@@ -1,0 +1,36 @@
+param(
+    [int]$X = 512,
+    [switch]$DryRun,
+    [switch]$Overwrite
+)
+$dest = "within_${X}_resolution"
+New-Item -ItemType Directory -Force -Path $dest | Out-Null
+
+function Avg-Dim {
+    param([string]$File)
+    $wh = ffprobe -v error -select_streams v:0 -show_entries stream=width,height -of csv=p=0:s=x $File 2>$null | Select-Object -First 1
+    if (-not $wh) { return $null }
+    $parts = $wh -split 'x'
+    if ($parts.Length -ne 2) { return $null }
+    return [int](([int]$parts[0] + [int]$parts[1]) / 2)
+}
+
+$processed=0; $moved=0; $kept=0; $warned=0
+Get-ChildItem -Path . -Filter *.mp4 -File | ForEach-Object {
+    $processed++
+    $ad = Avg-Dim $_.FullName
+    if (-not ($ad -is [int])) { Write-Host "WARN  $($_.Name): could not read resolution"; $warned++; return }
+    if ($ad -le $X) {
+        Write-Host "MOVE  $($_.Name)  (avg_dim=$ad <= $X) -> $dest/"
+        if (-not $DryRun) {
+            $moveArgs = @{}
+            if ($Overwrite) { $moveArgs.Force = $true }
+            Move-Item -LiteralPath $_.FullName -Destination $dest @moveArgs
+        }
+        $moved++
+    } else {
+        Write-Host "KEEP  $($_.Name)  (avg_dim=$ad > $X)"
+        $kept++
+    }
+}
+Write-Host "Done. processed=$processed moved=$moved kept=$kept warned=$warned dest=$dest"

--- a/reverse_videos_max_frames.ps1
+++ b/reverse_videos_max_frames.ps1
@@ -1,0 +1,50 @@
+param(
+    [int]$MaxFrames = 101,
+    [int]$CRF = 18,
+    [string]$PRESET = "slow",
+    [string]$CODEC = "libx264",
+    [switch]$KeepAudio,
+    [switch]$Overwrite,
+    [switch]$DryRun
+)
+$outDir = "reversed"
+New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+
+function Count-Frames {
+    param([string]$File)
+    $nb = ffprobe -v error -select_streams v:0 -count_frames -show_entries stream=nb_read_frames -of default=nw=1:nk=1 $File 2>$null
+    if ($nb -match '^[0-9]+$' -and [int]$nb -gt 0) { return [int]$nb }
+    $dur = ffprobe -v error -show_entries format=duration -of default=nw=1:nk=1 $File 2>$null
+    if (-not $dur) { $dur = 0 }
+    $rate = ffprobe -v error -select_streams v:0 -show_entries stream=avg_frame_rate -of default=nw=1:nk=1 $File 2>$null
+    if (-not $rate) { $rate = '0/1' }
+    $parts = $rate -split '/'
+    if ($parts.Length -ne 2 -or [int]$parts[1] -eq 0) { return 0 }
+    $fps = [double]$parts[0] / [double]$parts[1]
+    return [int]([double]$dur * $fps)
+}
+
+function Has-Audio {
+    param([string]$File)
+    $out = ffprobe -v error -select_streams a -show_entries stream=index -of csv=p=0 $File 2>$null
+    return -not [string]::IsNullOrEmpty($out)
+}
+
+$ffw = '-n'; if ($Overwrite) { $ffw = '-y' }
+$processed=0; $made=0; $skipped=0; $warned=0
+Get-ChildItem -Path . -Filter *.mp4 -File | ForEach-Object {
+    $processed++
+    $frames = Count-Frames $_.FullName
+    if (-not ($frames -is [int])) { Write-Host "WARN  $($_.Name): could not determine frame count"; $warned++; return }
+    if ($frames -gt $MaxFrames) { Write-Host "SKIP  $($_.Name)  ($frames > $MaxFrames)"; $skipped++; return }
+    $out = Join-Path $outDir ("$($_.BaseName)_reversed.mp4")
+    Write-Host "MAKE  $($_.Name)  ($frames ≤ $MaxFrames) -> $out"
+    if ($DryRun) { $made++; return }
+    if ($KeepAudio -and (Has-Audio $_.FullName)) {
+        ffmpeg $ffw -hide_banner -loglevel error -i $_.FullName -filter_complex "[0:v]reverse[v];[0:a]areverse[a]" -map "[v]" -map "[a]" -c:v $CODEC -preset $PRESET -crf $CRF -pix_fmt yuv420p -c:a aac -b:a 128k -movflags +faststart $out
+    } else {
+        ffmpeg $ffw -hide_banner -loglevel error -i $_.FullName -an -vf reverse -c:v $CODEC -preset $PRESET -crf $CRF -pix_fmt yuv420p -movflags +faststart $out
+    }
+    $made++
+}
+Write-Host "Done. processed=$processed  made=$made  skipped=$skipped  warnings=$warned  outdir=$outDir"


### PR DESCRIPTION
## Summary
- document new dataset helper scripts in README
- add PowerShell equivalents for condensing clips, palindrome creation, frame-based moving, resolution filtering, and reversing

## Testing
- `bash -n condenseMP4s_to_target_frames.sh move_under_frames.sh reverse_videos_max_frames.sh make_palindromes.sh move_within_x_resolution.sh`
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b1317cc7f8832bac98f6525de26633